### PR TITLE
fix crashes in test::ReadSDO

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 project(canopen_master)
-cmake_minimum_required(VERSION 2.6)
+cmake_minimum_required(VERSION 3.1)
 
 set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/.orogen/config")
 include(canopen_masterBase)

--- a/tasks/SlaveTask.hpp
+++ b/tasks/SlaveTask.hpp
@@ -77,6 +77,10 @@ namespace canopen_master{
         void writeSDO(canbus::Message const& query,
                       base::Time timeout = base::Time::fromSeconds(1));
 
+        void writeProducerHeartbeatPeriod(
+            base::Time const& period, base::Time const& timeout
+        );
+
     public:
         /** TaskContext constructor for SlaveTask
          * \param name Name of the task. This name needs to be unique to make it identifiable via nameservices.

--- a/tasks/test/ReadSDO.cpp
+++ b/tasks/test/ReadSDO.cpp
@@ -57,6 +57,8 @@ void ReadSDO::stopHook()
 void ReadSDO::cleanupHook()
 {
     delete m_slave;
+    m_slave = nullptr;
     delete m_state_machine;
+    m_state_machine = nullptr;
     ReadSDOBase::cleanupHook();
 }


### PR DESCRIPTION
RTT calls cleanupHook twice in the event of an exception. Once during
the running->exception transition and once during exception->pre_operational

I always assumed that cleanupHook would be called only once per
call to configureHook *and that's it*. But it's not the case.

In test::ReadSDO's configureHook, this led to a double-free

Unexpected behavior reported in https://github.com/orocos-toolchain/rtt/issues/318