### PR TITLE
fix random failure in tests

### DIFF
--- a/test/slave_task_test.rb
+++ b/test/slave_task_test.rb
@@ -1,15 +1,15 @@
 # frozen_string_literal: true
 
-using_task_library 'canopen_master'
+using_task_library "canopen_master"
 
 describe OroGen.canopen_master.SlaveTask do
     run_live
 
-    describe 'SDO read' do
+    describe "SDO read" do
         attr_reader :task
         before do
             @task = syskit_deploy(
-                OroGen.canopen_master.test.ReadSDO.deployed_as('read_sdo')
+                OroGen.canopen_master.test.ReadSDO.deployed_as("read_sdo")
             )
             task.properties.node_id = 0x42
             syskit_configure(task)
@@ -17,7 +17,7 @@ describe OroGen.canopen_master.SlaveTask do
                       .to { have_one_new_sample task.can_out_port }
         end
 
-        it 'reads a SDO' do
+        it "reads a SDO" do
             assert_sdo_upload(@sample, 0x42, 0x210D, 0x2)
 
             # SDO Upload Reply, 2 bytes, ID=0x210D Sub=2, data = 0x190
@@ -27,28 +27,28 @@ describe OroGen.canopen_master.SlaveTask do
             assert_equal 0x190, value
         end
 
-        it 'times out of the SDO upload reply is not received' do
+        it "times out of the SDO upload reply is not received" do
             expect_execution.to { emit task.sdo_timeout_event }
         end
 
-        it 'ignores SDO upload replies not for the read object ID' do
+        it "ignores SDO upload replies not for the read object ID" do
             sdo_transmit = make_sdo_upload_reply(0x42, 0x200D, 0x2, 0x1, 0x90)
             expect_execution { syskit_write task.can_in_port, sdo_transmit }
                 .to { emit task.sdo_timeout_event }
         end
 
-        it 'ignores SDO upload replies not for the read object subID' do
+        it "ignores SDO upload replies not for the read object subID" do
             sdo_transmit = make_sdo_upload_reply(0x42, 0x210D, 0x1, 0x1, 0x90)
             expect_execution { syskit_write task.can_in_port, sdo_transmit }
                 .to { emit task.sdo_timeout_event }
         end
     end
 
-    describe 'SDO write' do
+    describe "SDO write" do
         attr_reader :task
         before do
             @task = syskit_deploy(
-                OroGen.canopen_master.test.WriteSDO.deployed_as('write_sdo')
+                OroGen.canopen_master.test.WriteSDO.deployed_as("write_sdo")
             )
             task.properties.node_id = 0x42
             syskit_configure(task)
@@ -56,7 +56,7 @@ describe OroGen.canopen_master.SlaveTask do
                       .to { have_one_new_sample task.can_out_port }
         end
 
-        it 'writes a SDO' do
+        it "writes a SDO" do
             assert_sdo_download(@sample, 0x42, 0x210D, 0x2, 0x1, 0x90)
 
             # SDO Download Reply, 2 bytes, ID=0x210D Sub=2
@@ -65,28 +65,28 @@ describe OroGen.canopen_master.SlaveTask do
                 .to { emit task.stop_event }
         end
 
-        it 'times out of the SDO download reply is not received' do
+        it "times out of the SDO download reply is not received" do
             expect_execution.to { emit task.sdo_timeout_event }
         end
 
-        it 'ignores SDO download replies not for the read object ID' do
+        it "ignores SDO download replies not for the read object ID" do
             sdo_reply = make_sdo_download_reply(0x42, 0x200D, 0x2)
             expect_execution { syskit_write task.can_in_port, sdo_reply }
                 .to { emit task.sdo_timeout_event }
         end
 
-        it 'ignores SDO upload replies not for the read object subID' do
+        it "ignores SDO upload replies not for the read object subID" do
             sdo_reply = make_sdo_download_reply(0x42, 0x210D, 0x1)
             expect_execution { syskit_write task.can_in_port, sdo_reply }
                 .to { emit task.sdo_timeout_event }
         end
     end
 
-    describe 'NMT RESET transition' do
+    describe "NMT RESET transition" do
         attr_reader :task
         before do
             @task = syskit_deploy(
-                OroGen.canopen_master.test.NMTResetCommunication.deployed_as('nmt')
+                OroGen.canopen_master.test.NMTResetCommunication.deployed_as("nmt")
             )
             task.properties.node_id = 0x42
             syskit_configure(task)
@@ -94,28 +94,29 @@ describe OroGen.canopen_master.SlaveTask do
                       .to { have_one_new_sample task.can_out_port }
         end
 
-        it 'sends the NMT reset communication message and waits for the node to send the bootup message' do
+        it "sends the NMT reset communication message and waits for the node "\
+           "to send the bootup message" do
             assert_nmt(@sample, 0x42, 130)
             expect_on_can_in(make_heartbeat(0x42, 0))
                 .to { emit task.stop_event }
         end
 
-        it 'ignores a heartbeat from another node' do
+        it "ignores a heartbeat from another node" do
             expect_on_can_in(make_heartbeat(0x41, 0))
                 .to { emit task.nmt_timeout_event }
         end
 
-        it 'ignores a heartbeat that indicate a different state than pre-operational' do
+        it "ignores a heartbeat that indicate a different state than pre-operational" do
             expect_on_can_in(make_heartbeat(0x42, 1))
                 .to { emit task.nmt_timeout_event }
         end
     end
 
-    describe 'NMT transition that is not RESET' do
+    describe "NMT transition that is not RESET" do
         attr_reader :task
         before do
             @task = syskit_deploy(
-                OroGen.canopen_master.test.NMTStateChange.deployed_as('nmt')
+                OroGen.canopen_master.test.NMTStateChange.deployed_as("nmt")
             )
             task.properties.node_id = 0x42
             syskit_configure(task)
@@ -123,19 +124,24 @@ describe OroGen.canopen_master.SlaveTask do
                       .to { have_one_new_sample task.can_out_port }
         end
 
-        it 'sets hearbeat, sends the NMT message and waits for the node to report the new NMT state and then reinitializes the heartbeat period' do
-            assert_sdo_download(@sample, 0x42, 0x1017, 0, 0, 0x64) # heartbeat producer, 100ms
+        it "sets hearbeat, sends the NMT message and waits for the node to report "\
+           "the new NMT state and then reinitializes the heartbeat period" do
+            # heartbeat producer, 100ms
+            assert_sdo_download(@sample, 0x42, 0x1017, 0, 0, 0x64)
             @sample = expect_on_can_in(make_sdo_download_reply(0x42, 0x1017, 0))
                       .to { have_one_new_sample task.can_out_port }
             assert_nmt(@sample, 0x42, 1) # start remote node
-            @sample = expect_on_can_in(make_heartbeat(0x42, 5)) # heartbeat, operational
+            # heartbeat, operational
+            @sample = expect_on_can_in(make_heartbeat(0x42, 5))
                       .to { have_one_new_sample task.can_out_port }
-            assert_sdo_download(@sample, 0x42, 0x1017, 0, 0x3, 0xE8) # heartbeat producer, 1s
-            expect_on_can_in(make_sdo_download_reply(0x42, 0x1017, 0)) # heartbeat, operational
+            # heartbeat producer, 1s
+            assert_sdo_download(@sample, 0x42, 0x1017, 0, 0x3, 0xE8)
+            # heartbeat, operational
+            expect_on_can_in(make_sdo_download_reply(0x42, 0x1017, 0))
                 .to { emit task.stop_event }
         end
 
-        it 'times out if the heartbeat with the expected state is not received' do
+        it "times out if the heartbeat with the expected state is not received" do
             expect_on_can_in(make_sdo_download_reply(0x42, 0x1017, 0))
                 .to { have_one_new_sample task.can_out_port }
             @sample = expect_on_can_in(make_heartbeat(0x42, 4))
@@ -163,7 +169,7 @@ describe OroGen.canopen_master.SlaveTask do
         assert_equal expected_data, sample.data.to_a
     end
 
-    def make_sdo_upload_reply(node_id, object_id, object_sub_id, *bytes)
+    def make_sdo_upload_reply(node_id, object_id, object_sub_id, *bytes) # rubocop:disable Metrics/AbcSize
         Types.canbus.Message.new(
             time: Time.now,
             can_id: (0x580 + node_id), size: 8,
@@ -176,9 +182,9 @@ describe OroGen.canopen_master.SlaveTask do
         )
     end
 
-    def assert_sdo_download(sample, node_id, object_id, object_sub_id, *bytes)
-        assert_equal (0x600 + node_id), sample.can_id, 'unexpected CAN ID'
-        assert_equal 8, sample.size, 'unexpected CAN package size'
+    def assert_sdo_download(sample, node_id, object_id, object_sub_id, *bytes) # rubocop:disable Metrics/AbcSize
+        assert_equal (0x600 + node_id), sample.can_id, "unexpected CAN ID"
+        assert_equal 8, sample.size, "unexpected CAN package size"
 
         expected_data = [
             0x23 | (4 - bytes.size) << 2,
@@ -202,9 +208,9 @@ describe OroGen.canopen_master.SlaveTask do
     end
 
     def assert_nmt(sample, node_id, command)
-        assert_equal 0, sample.can_id, 'unexpectedc CAN ID'
-        assert_equal command, sample.data[0], 'unexpected command ID'
-        assert_equal node_id, sample.data[1], 'unexpected node ID'
+        assert_equal 0, sample.can_id, "unexpectedc CAN ID"
+        assert_equal command, sample.data[0], "unexpected command ID"
+        assert_equal node_id, sample.data[1], "unexpected node ID"
     end
 
     def make_heartbeat(node_id, state)

--- a/test/slave_task_test.rb
+++ b/test/slave_task_test.rb
@@ -165,6 +165,7 @@ describe OroGen.canopen_master.SlaveTask do
 
     def make_sdo_upload_reply(node_id, object_id, object_sub_id, *bytes)
         Types.canbus.Message.new(
+            time: Time.now,
             can_id: (0x580 + node_id), size: 8,
             data: [
                 0x43 | ((4 - bytes.size) << 2),
@@ -190,6 +191,7 @@ describe OroGen.canopen_master.SlaveTask do
 
     def make_sdo_download_reply(node_id, object_id, object_sub_id)
         Types.canbus.Message.new(
+            time: Time.now,
             can_id: (0x580 + node_id), size: 8,
             data: [
                 0x60,
@@ -207,6 +209,7 @@ describe OroGen.canopen_master.SlaveTask do
 
     def make_heartbeat(node_id, state)
         Types.canbus.Message.new(
+            time: Time.now,
             can_id: 1792 + node_id,
             size: 1,
             data: [state, 0, 0, 0, 0, 0, 0, 0]


### PR DESCRIPTION
The timestamp would sometimes be zero, which was ultimately rejected
by the CANopen implementation: the null timestamp would cause the
dictionary to believe that there was no data, and get() would fail.

The error is made more explicit in canopen_master by https://github.com/rock-drivers/drivers-canopen_master/pull/4